### PR TITLE
Fix generating the spatial structure

### DIFF
--- a/src/IFC/Components/PropertyManager.ts
+++ b/src/IFC/Components/PropertyManager.ts
@@ -72,7 +72,12 @@ export class PropertyManager {
             const rel = this.state.api.GetLine(modelID, relation.get(i), false);
             const relating = rel[propNames.relating].value;
             const related = rel[propNames.related].map((r: any) => r.value);
-            chunks[relating] = related;
+            if(chunks[relating] == undefined){
+                chunks[relating] = related;
+            }
+            else{
+                 chunks[relating] = chunks[relating].concat(related);
+            }
         }
     }
 


### PR DESCRIPTION
Calling the functions getChunks two times overwrite the treeChunks variable.
Fixed using concat.
![image](https://user-images.githubusercontent.com/82835289/124512054-81aef000-dda5-11eb-9baa-427b58d35827.png)
