### PR TITLE
Fix 'Maximum call stack size exceeded' exception

### DIFF
--- a/web-ifc-three/src/IFC/Components/ItemsHider.ts
+++ b/web-ifc-three/src/IFC/Components/ItemsHider.ts
@@ -39,7 +39,11 @@ export class ItemsHider {
         const current = this.expressIDCoordinatesMap[modelID];
         const indices: number[] = [];
         ids.forEach((id: number) => {
-            if (current[id]) indices.push(...current[id]);
+            if (current[id]) {
+                for (let i = 0; i < current[id].length; i++) {
+                    indices.push(current[id][i]);
+                }
+            }
         });
         const coords = this.getCoordinates(modelID);
         const initial = this.modelCoordinates[modelID];


### PR DESCRIPTION
If an array is long enough (over 125450 items in my tests), "three dots" notation throws a `Maximum call stack size exceeded` exception.