### PR TITLE
Model's mesh is not removed from scene when close model

### DIFF
--- a/web-ifc-three/src/IFC/Components/IFCManager.ts
+++ b/web-ifc-three/src/IFC/Components/IFCManager.ts
@@ -113,7 +113,8 @@ export class IFCManager {
     close(modelID: number, scene?: Scene) {
         this.state.api.CloseModel(modelID);
         if (scene) {
-            scene.remove(this.state.models[modelID].mesh);
+            const mesh = scene.children.find((child) => child.modelID === modelID);
+            scene.remove(mesh);
         }
         delete this.state.models[modelID];
     }


### PR DESCRIPTION
Since this [change](https://github.com/IFCjs/web-ifc-three/commit/41f254c691d0dfdf3a73daf660e4ff500845a3f4#diff-7e4d7ee573d2d03d466ca72372c22f07e6522dccc0253e8db5d3988abe28b172L26-L29), IFCModel's mesh and mesh managed by IFCManager are not same instance.

So, model's mesh is not removed from scene when I invoke IFCManager's `close()` method in web-ifc-viewer.