### PR TITLE
Fix IFCModel.modelID - take a parameter instead of generating the ID on its own

### DIFF
--- a/example/IFCWorker.js
+++ b/example/IFCWorker.js
@@ -42183,12 +42183,11 @@ if ( typeof window !== 'undefined' ) {
 
 }
 
-let modelIdCounter = 0;
 const nullIfcManagerErrorMessage = 'IfcManager is null!';
 class IFCModel extends Mesh {
-    constructor() {
-        super(...arguments);
-        this.modelID = modelIdCounter++;
+    constructor(modelID, geometry, material) {
+        super(geometry, material);
+        this.modelID = modelID;
         this.ifcManager = null;
         this.mesh = this;
     }
@@ -42258,23 +42257,6 @@ class IFCModel extends Mesh {
     }
 }
 
-class SerializedMaterial {
-    constructor(material) {
-        this.color = [material.color.r, material.color.g, material.color.b];
-        this.opacity = material.opacity;
-        this.transparent = material.transparent;
-    }
-}
-class MaterialReconstructor {
-    static new(material) {
-        return new MeshLambertMaterial({
-            color: new Color(material.color[0], material.color[1], material.color[2]),
-            opacity: material.opacity,
-            transparent: material.transparent
-        });
-    }
-}
-
 class SerializedGeometry {
     constructor(geometry) {
         var _a, _b, _c, _d;
@@ -42302,6 +42284,23 @@ class GeometryReconstructor {
     }
 }
 
+class SerializedMaterial {
+    constructor(material) {
+        this.color = [material.color.r, material.color.g, material.color.b];
+        this.opacity = material.opacity;
+        this.transparent = material.transparent;
+    }
+}
+class MaterialReconstructor {
+    static new(material) {
+        return new MeshLambertMaterial({
+            color: new Color(material.color[0], material.color[1], material.color[2]),
+            opacity: material.opacity,
+            transparent: material.transparent
+        });
+    }
+}
+
 class SerializedMesh {
     constructor(model) {
         this.materials = [];
@@ -42319,9 +42318,7 @@ class SerializedMesh {
 }
 class MeshReconstructor {
     static new(serialized) {
-        const model = new IFCModel();
-        model.modelID = serialized.modelID;
-        model.geometry = GeometryReconstructor.new(serialized.geometry);
+        const model = new IFCModel(serialized.modelID, GeometryReconstructor.new(serialized.geometry));
         MeshReconstructor.getMaterials(serialized, model);
         return model;
     }
@@ -87225,7 +87222,7 @@ class IFCParser {
         this.cleanUpGeometryMemory(geometries);
         if (this.BVH)
             this.BVH.applyThreeMeshBVH(combinedGeometry);
-        const model = new IFCModel(combinedGeometry, materials);
+        const model = new IFCModel(this.currentModelID, combinedGeometry, materials);
         this.state.models[this.currentModelID].mesh = model;
         return model;
     }

--- a/web-ifc-three/src/IFC/components/IFCModel.ts
+++ b/web-ifc-three/src/IFC/components/IFCModel.ts
@@ -1,8 +1,7 @@
-import { BufferGeometry, Material, Mesh, Object3D, Scene } from 'three';
-import { IFCManager } from './IFCManager';
+import { BufferGeometry, Material, Mesh, Scene } from 'three';
 import { BaseSubsetConfig } from '../BaseDefinitions';
+import { IFCManager } from './IFCManager';
 
-let modelIdCounter = 0;
 const nullIfcManagerErrorMessage = 'IfcManager is null!';
 
 /**
@@ -12,7 +11,11 @@ const nullIfcManagerErrorMessage = 'IfcManager is null!';
  * @manager contains all the logic to work with IFC.
  */
 export class IFCModel extends Mesh {
-    modelID = modelIdCounter++;
+    constructor (public readonly modelID: number,
+      geometry?: BufferGeometry, material?: Material | Material[]) {
+      super(geometry, material);
+    }
+
     ifcManager: IFCManager | null = null;
 
     /**

--- a/web-ifc-three/src/IFC/components/IFCParser.ts
+++ b/web-ifc-three/src/IFC/components/IFCParser.ts
@@ -1,16 +1,11 @@
 //@ts-ignore
-import { PlacedGeometry, Color as ifcColor, IfcGeometry, IFCSPACE, FlatMesh, IFCOPENINGELEMENT } from 'web-ifc';
-import { IfcState, IfcMesh } from '../BaseDefinitions';
 import {
-    Color,
-    MeshLambertMaterial,
-    DoubleSide,
-    Matrix4,
-    BufferGeometry,
-    BufferAttribute,
-    Mesh
+  BufferAttribute, BufferGeometry, Color, DoubleSide,
+  Matrix4, Mesh, MeshLambertMaterial
 } from 'three';
 import { mergeBufferGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils';
+import { Color as ifcColor, FlatMesh, IfcGeometry, IFCOPENINGELEMENT, IFCSPACE, PlacedGeometry } from 'web-ifc';
+import { IfcMesh, IfcState } from '../BaseDefinitions';
 import { BvhManager } from './BvhManager';
 import { IFCModel } from './IFCModel';
 
@@ -118,7 +113,7 @@ export class IFCParser implements ParserAPI {
         const combinedGeometry = mergeBufferGeometries(geometries, true);
         this.cleanUpGeometryMemory(geometries);
         if (this.BVH) this.BVH.applyThreeMeshBVH(combinedGeometry);
-        const model = new IFCModel(combinedGeometry, materials);
+        const model = new IFCModel(this.currentModelID, combinedGeometry, materials);
         this.state.models[this.currentModelID].mesh = model;
         return model;
     }

--- a/web-ifc-three/src/IFC/web-workers/serializer/Mesh.ts
+++ b/web-ifc-three/src/IFC/web-workers/serializer/Mesh.ts
@@ -1,7 +1,7 @@
-import { IFCModel } from '../../components/IFCModel';
 import { Material, MeshLambertMaterial } from 'three';
-import { MaterialReconstructor, SerializedMaterial } from './Material';
+import { IFCModel } from '../../components/IFCModel';
 import { GeometryReconstructor, SerializedGeometry } from './Geometry';
+import { MaterialReconstructor, SerializedMaterial } from './Material';
 
 export class SerializedMesh {
 
@@ -25,9 +25,8 @@ export class SerializedMesh {
 export class MeshReconstructor {
 
     static new(serialized: SerializedMesh) {
-        const model = new IFCModel();
-        model.modelID = serialized.modelID;
-        model.geometry = GeometryReconstructor.new(serialized.geometry);
+        const model = new IFCModel(serialized.modelID,
+          GeometryReconstructor.new(serialized.geometry));
         MeshReconstructor.getMaterials(serialized, model);
         return model;
     }


### PR DESCRIPTION
Hello,

First of all - thanks for the work on this project!

I have started playing with the web-ifc-viewer, but pretty soon, I have hit a bug when recreating the viewer.
It seems to be caused by the way IFCModel.modelID were assigned - they were incremented using an global variable, while the IFCManager would use its own numbering for every instance of itself.

Sadly, there are no tests for this, but perhaps you can tell me if this fix makes sense. :) Thanks!