### PR TITLE
ensure working iteration even when prototypes have been modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ This project consists of the following folders:
 
 Want to help out? Great!
 
-Please checkout [our contribution suggestsions](https://github.com/IFCjs/web-ifc-three/blob/main/contributing.md) or speak to us directly in [Discord](https://discord.gg/FXfyR4XrKT).
+Please checkout [our contribution suggestions](https://github.com/IFCjs/web-ifc-three/blob/main/CONTRIBUTING.md) or speak to us directly in [Discord](https://discord.gg/FXfyR4XrKT).

--- a/web-ifc-three/src/IFC/components/TypeManager.ts
+++ b/web-ifc-three/src/IFC/components/TypeManager.ts
@@ -13,12 +13,14 @@ export class TypeManager {
     }
 
     async getAllTypes(worker?: IFCWorkerHandler){
-        for(let modelID in this.state.models){
-            const types = this.state.models[modelID].types;
-            if(Object.keys(types).length == 0) {
-                await this.getAllTypesOfModel(parseInt(modelID), worker);
-            }
-        }
+		for (let modelID in this.state.models) {
+			if (this.state.models.hasOwnProperty(modelID)) {
+				const types = this.state.models[modelID].types;
+				if (Object.keys(types).length == 0) {
+					await this.getAllTypesOfModel(parseInt(modelID), worker);
+				}
+			}
+		}
     }
 
     async getAllTypesOfModel(modelID: number, worker?: IFCWorkerHandler) {


### PR DESCRIPTION
When iterating through an object it's a good practice to make a check with hasOwnProperty to ensure that accidental iteration of the object's prototype properties doesn't happen. This prevents problems for example when Object's or Array's prototypes have been modified.

This will fix #84 