### PR TITLE
Feat: get all subsets

### DIFF
--- a/web-ifc-three/src/IFC/components/subsets/SubsetManager.ts
+++ b/web-ifc-three/src/IFC/components/subsets/SubsetManager.ts
@@ -30,6 +30,10 @@ export class SubsetManager {
         this.subsetCreator = new SubsetCreator(state, this.items, this.subsets, this.BVH);
     }
 
+    getAllSubsets(){
+        return this.subsets
+    }
+
     getSubset(modelID: number, material?: Material, customId?: string) {
         const subsetID = this.getSubsetID(modelID, material, customId);
         return this.subsets[subsetID].mesh;


### PR DESCRIPTION
Hello, this is my first PR for the great IFC.js code!
I am having a use case where in web-ifc-viewer I want to apply the clipper to all subsets, cause right now it clips only the main mesh.
So I don't know why you guys made the subsets private, so I did not want to make it public or read only.
So the goal of this PR is allowing retrieving all the Subsets so then in the clipper of web-ifc-viewer we can clip all subsets or even some of them as parameter.
The PR for web-ifc-viewer is coming soon, but it will look like this 


```      
// file web-ifc-viewer/viewer/src/components/display/clipping-planes/clipper.ts

private updateMaterials = () => {
    const planes = this.context.getClippingPlanes();
    // Applying clipping to all subsets. then we can also filter and apply only to specified subsest as parameter

    Object.values(this.ifc.loader.ifcManager.subsets.getAllSubsets())forEach((subset: any) => {
      const mesh = subset.mesh as Mesh;
      if (mesh.material) this.updateMaterial(mesh, planes);
      if (mesh.userData.wireframe) this.updateMaterial(mesh.userData.wireframe, planes);
    });=> {
      const mesh = subset.mesh as Mesh;
      if (mesh.material) this.updateMaterial(mesh, planes);
      if (mesh.userData.wireframe) this.updateMaterial(mesh.userData.wireframe, planes);
    });
    });
```