### PR TITLE
Fix SetWasmPath with absolute path

### DIFF
--- a/web-ifc-three/src/IFC/BaseDefinitions.ts
+++ b/web-ifc-three/src/IFC/BaseDefinitions.ts
@@ -204,5 +204,5 @@ export interface WebIfcAPI {
      */
     GetFlatMesh(modelID: number, expressID: number): FlatMesh | Promise<FlatMesh>;
 
-    SetWasmPath(path: string): void | Promise<void>;
+    SetWasmPath(path: string, absolute?: boolean): void | Promise<void>;
 }

--- a/web-ifc-three/src/IFC/components/IFCManager.ts
+++ b/web-ifc-three/src/IFC/components/IFCManager.ts
@@ -80,7 +80,10 @@ export class IFCManager {
      * @path Relative path to web-ifc.wasm.
      */
     async setWasmPath(path: string) {
-        this.state.api.SetWasmPath(path);
+        // If the path starts with a slash, it is considered an absolute path.
+        const isAbsolutePath = path.indexOf('/') === 0
+
+        this.state.api.SetWasmPath(path, isAbsolutePath);
         this.state.wasmPath = path;
     }
 

--- a/web-ifc-three/src/IFC/web-workers/handlers/WebIfcHandler.ts
+++ b/web-ifc-three/src/IFC/web-workers/handlers/WebIfcHandler.ts
@@ -144,7 +144,7 @@ export class WebIfcHandler implements WebIfcAPI {
         return this.handler.request(this.API, WorkerActions.GetFlatMesh, { modelID, expressID });
     }
 
-    async SetWasmPath(path: string): Promise<void> {
-        return this.handler.request(this.API, WorkerActions.SetWasmPath, { path });
+    async SetWasmPath(path: string, absolute?: boolean): Promise<void> {
+        return this.handler.request(this.API, WorkerActions.SetWasmPath, { path, absolute });
     }
 }

--- a/web-ifc-three/src/IFC/web-workers/workers/WebIfcWorker.ts
+++ b/web-ifc-three/src/IFC/web-workers/workers/WebIfcWorker.ts
@@ -132,7 +132,7 @@ export class WebIfcWorker implements WebIfcWorkerAPI {
     }
 
     SetWasmPath(data: IfcEventData) {
-        this.webIFC.SetWasmPath(data.args.path);
+        this.webIFC.SetWasmPath(data.args.path, data.args.absolute);
         this.worker.post(data);
     }
 


### PR DESCRIPTION
For absolute paths starting with a slash(e.g. `/wasm/`), `SetWasmpath` does not work properly.
In this case, pass the `absolute` parameter to `true`.