### PR TITLE
Update IfcManager.ts close()

### DIFF
--- a/web-ifc-three/src/IFC/components/IFCManager.ts
+++ b/web-ifc-three/src/IFC/components/IFCManager.ts
@@ -197,9 +197,19 @@ export class IFCManager {
      * @scene Scene where the model is (if it's located in a scene).
      */
     close(modelID: number, scene?: Scene) {
-        this.state.api.CloseModel(modelID);
-        if (scene) scene.remove(this.state.models[modelID].mesh);
-        delete this.state.models[modelID];
+        try {
+            this.state.api.CloseModel(modelID);
+            const mesh = this.state.models[modelID].mesh;
+            const { geometry, material } = mesh;
+            if (scene) scene.remove(mesh);
+            geometry?.dispose();
+            geometry = null;
+            Array.isArray(material) ? material.forEach(m => m.dispose()) : material?.dispose();
+            material = null;
+            delete this.state.models[modelID];
+        } catch(e) {
+            console.warn(`Close IFCModel ${modelID} failed`);
+        }
     }
 
     /**

--- a/web-ifc-three/src/IFC/components/IFCManager.ts
+++ b/web-ifc-three/src/IFC/components/IFCManager.ts
@@ -203,9 +203,7 @@ export class IFCManager {
             const { geometry, material } = mesh;
             if (scene) scene.remove(mesh);
             geometry?.dispose();
-            geometry = null;
             Array.isArray(material) ? material.forEach(m => m.dispose()) : material?.dispose();
-            material = null;
             delete this.state.models[modelID];
         } catch(e) {
             console.warn(`Close IFCModel ${modelID} failed`);


### PR DESCRIPTION
Update IfcManager.ts close: 

Update `close()`, to avoid memory leaking, by disposing geometry and material of IFCModel on closing.

resolves #145