### PR TITLE
Specify colors as sRGB-Rec709-D65 for color management

### DIFF
--- a/web-ifc-three/src/IFC/components/IFCParser.ts
+++ b/web-ifc-three/src/IFC/components/IFCParser.ts
@@ -215,7 +215,10 @@ export class IFCParser implements ParserAPI {
             return;
         }
 
-        const col = new Color(color.x, color.y, color.z);
+        // Assume RGB components are in sRGB-Rec709-D65 colorspace, and specify
+        // this so three.js can convert if THREE.ColorManagement APIs are enabled.
+        // TODO: https://github.com/three-types/three-ts-types/issues/342
+        const col = new Color().setRGB(color.x, color.y, color.z, 'srgb');
         const material = new MeshLambertMaterial({ color: col, side: DoubleSide });
         material.transparent = color.w !== 1;
         if (material.transparent) material.opacity = color.w;


### PR DESCRIPTION
Hi! The three.js project is working toward improved color management workflows, which are necessary for better lighting, PBR shading, and upcoming WebGL / WebGPU features like wide-gamut color spaces. As part of that, we've added a [color management guide](https://threejs.org/docs/#manual/en/introduction/Color-management). One thing to note there is a new THREE.ColorManagement API:

```javascript
THREE.ColorManagement.enabled = true; // r150+
```

It's called `legacyMode = false` in the current release but should be renamed as shown above soon:

- https://github.com/mrdoob/three.js/pull/24940

Under this mode, RGB components are assumed to be in Linear-sRGB colorspace by default, and that conflicts with current usage here. I don't know what color management information exists for IFC models, whether configurable or not. But (without this PR) the new mode changes display of colors in IFC models, which you probably don't want!

Based on the current example in the repository, I'm assuming that material colors for IFC models are given in sRGB color space (sRBG transfer function, Rec 709 primaries, D65 white point). This PR specifies colorspace when configuring the material, so that:

1. If THREE.ColorManagement APIs *are not* enabled, nothing changes.
2. If THREE.ColorManagement APIs *are* enabled, the color is automatically converted to Linear-sRGB as required for a linear rendering workflow.
