### PR TITLE
Expose GUID mapping through web worker

### DIFF
--- a/src/IFC/BaseDefinitions.ts
+++ b/src/IFC/BaseDefinitions.ts
@@ -1,0 +1,227 @@
+import { BufferAttribute, BufferGeometry, Material, Matrix4, Mesh, Object3D } from 'three';
+// TODO: Remove ts ignore comments when @types/three gets updated
+// @ts-ignore
+import { mergeBufferGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils';
+import {
+    FlatMesh,
+    IfcGeometry,
+    IFCRELAGGREGATES, IFCRELASSOCIATESMATERIAL,
+    IFCRELCONTAINEDINSPATIALSTRUCTURE,
+    IFCRELDEFINESBYPROPERTIES,
+    IFCRELDEFINESBYTYPE, LoaderError, LoaderSettings, RawLineData, Vector
+} from 'web-ifc';
+import {ParserProgress} from "./components/IFCParser";
+
+export const IdAttrName = 'expressID';
+
+export type IdAttributeByMaterial = { [id: number]: number };
+export type IdAttributesByMaterials = { [materialID: string]: IdAttributeByMaterial };
+
+//TODO: Rename "scene" to "parent" in the next major release
+export interface BaseSubsetConfig {
+    scene?: Object3D;
+    ids: number[];
+    removePrevious: boolean;
+    material?: Material;
+    customID?: string;
+    applyBVH?: boolean;
+}
+
+export interface SubsetConfig extends BaseSubsetConfig {
+    modelID: number;
+}
+
+export const DEFAULT = 'default';
+
+export type MapFaceindexID = { [key: number]: number };
+
+export interface TypesMap {
+    [key: number]: number;
+}
+
+
+export interface IfcModel {
+    modelID: number;
+    mesh: IfcMesh;
+    types: TypesMap;
+    jsonData: { [id: number]: JSONObject };
+}
+
+export interface JSONObject {
+    expressID: number;
+    type: string;
+    [key: string]: any;
+}
+
+export interface Worker {
+    active: boolean;
+    path: string;
+}
+
+export interface IfcState {
+    models: { [modelID: number]: IfcModel };
+    api: WebIfcAPI;
+    useJSON: boolean;
+    worker: Worker;
+    webIfcSettings?: LoaderSettings;
+    onProgress?: (event: ParserProgress) => void;
+    coordinationMatrix?: Matrix4,
+    wasmPath?: string;
+}
+
+export interface IfcMesh extends Mesh {
+    modelID: number;
+}
+
+export interface Node {
+    expressID: number;
+    type: string;
+    children: Node[];
+}
+
+export interface pName {
+    name: number;
+    relating: string;
+    related: string;
+    key: string;
+}
+
+export interface NewIfcModel {
+    schema: string;
+    name?: string;
+    description?: string[];
+    authors?: string[];
+    organizations?: string[];
+    authorization?: string;
+}
+
+export const PropsNames = {
+    aggregates: {
+        name: IFCRELAGGREGATES,
+        relating: 'RelatingObject',
+        related: 'RelatedObjects',
+        key: 'children'
+    },
+    spatial: {
+        name: IFCRELCONTAINEDINSPATIALSTRUCTURE,
+        relating: 'RelatingStructure',
+        related: 'RelatedElements',
+        key: 'children'
+    },
+    psets: {
+        name: IFCRELDEFINESBYPROPERTIES,
+        relating: 'RelatingPropertyDefinition',
+        related: 'RelatedObjects',
+        key: 'hasPsets'
+    },
+    materials: {
+        name: IFCRELASSOCIATESMATERIAL,
+        relating: 'RelatingMaterial',
+        related: 'RelatedObjects',
+        key: 'hasMaterial'
+    },
+    type: {
+        name: IFCRELDEFINESBYTYPE,
+        relating: 'RelatingType',
+        related: 'RelatedObjects',
+        key: 'hasType'
+    }
+};
+
+export interface WebIfcAPI {
+
+    wasmModule: any;
+
+    Init(): void | Promise<void>;
+
+    // To close the web worker
+    Close?: () => void;
+
+    /**
+     * Opens a model and returns a modelID number
+     * @data Buffer containing IFC data (bytes)
+     * @data Settings settings for loading the model
+     */
+    OpenModel(data: string | Uint8Array, settings?: LoaderSettings): number | Promise<number>;
+
+    GetHeaderLine(modelID: number, headerType: number): any | Promise<any>;
+
+    /**
+     * Creates a new model and returns a modelID number
+     * @data Settings settings for generating data the model
+     */
+    CreateModel(model: NewIfcModel, settings?: LoaderSettings): number | Promise<number>;
+
+    ExportFileAsIFC(modelID: number): Uint8Array | Promise<Uint8Array>;
+
+    /**
+     * Opens a model and returns a modelID number
+     * @modelID Model handle retrieved by OpenModel, model must not be closed
+     * @data Buffer containing IFC data (bytes)
+     */
+    GetGeometry(modelID: number, geometryExpressID: number): IfcGeometry | Promise<IfcGeometry>;
+
+    GetLine(modelID: number, expressID: number, flatten?: boolean):  any | Promise<any>;
+
+    GetAndClearErrors(modelID: number): Vector<LoaderError> | Promise<Vector<LoaderError>>;
+
+    WriteLine(modelID: number, lineObject: any): void | Promise<void>;
+
+    FlattenLine(modelID: number, line: any): void | Promise<void>;
+
+    GetRawLineData(modelID: number, expressID: number): RawLineData | Promise<RawLineData>;
+
+    WriteRawLineData(modelID: number, data: RawLineData):  any | Promise<any>;
+
+    GetLineIDsWithType(modelID: number, type: number): Vector<number> | Promise<Vector<number>>;
+
+    GetAllLines(modelID: Number): Vector<number> | Promise<Vector<number>>;
+
+    SetGeometryTransformation(modelID: number, transformationMatrix: Array<number>): void | Promise<void>;
+
+    GetCoordinationMatrix(modelID: number): Array<number> | Promise<Array<number>>;
+
+    GetVertexArray(ptr: number, size: number): Float32Array | Promise<Float32Array>;
+
+    GetIndexArray(ptr: number, size: number): Uint32Array | Promise<Uint32Array>;
+
+    GetNameFromTypeCode(type:number): string | Promise<string>;
+
+    GetTypeCodeFromName(typeName:string): number | Promise<number>;
+
+    GetIfcEntityList(modelID: number) : Array<number> | Promise<Array<number>>;
+
+    CreateIfcGuidToExpressIdMapping(modelID: number): Map<string, number> | Promise<Map<string, number>>;
+
+    getSubArray(heap: any, startPtr: any, sizeBytes: any): any | Promise<any>;
+
+    /**
+     * Closes a model and frees all related memory
+     * @modelID Model handle retrieved by OpenModel, model must not be closed
+     */
+    CloseModel(modelID: number): void | Promise<void>;
+
+    StreamAllMeshes(modelID: number, meshCallback: (mesh: FlatMesh) => void): void | Promise<void>;
+
+    StreamAllMeshesWithTypes(modelID: number, types: Array<number>, meshCallback: (mesh: FlatMesh) => void): void | Promise<void>;
+
+    /**
+     * Checks if a specific model ID is open or closed
+     * @modelID Model handle retrieved by OpenModel
+     */
+    IsModelOpen(modelID: number): boolean | Promise<boolean>;
+
+    /**
+     * Load all geometry in a model
+     * @modelID Model handle retrieved by OpenModel
+     */
+    LoadAllGeometry(modelID: number): Vector<FlatMesh> | Promise<Vector<FlatMesh>>;
+
+    /**
+     * Load geometry for a single element
+     * @modelID Model handle retrieved by OpenModel
+     */
+    GetFlatMesh(modelID: number, expressID: number): FlatMesh | Promise<FlatMesh>;
+
+    SetWasmPath(path: string): void | Promise<void>;
+}

--- a/src/IFC/web-workers/BaseDefinitions.ts
+++ b/src/IFC/web-workers/BaseDefinitions.ts
@@ -1,0 +1,176 @@
+import { IfcState, WebIfcAPI } from '../BaseDefinitions';
+
+export interface IfcWorkerAPI {
+    post: (data: any) => void;
+    initializeAPI: (api: WebIfcAPI) => void;
+    state?: IfcState;
+    postCallback: (data: any, result: any, serializer?: any) => void;
+}
+
+export enum WorkerActions {
+    // Worker State Actions
+    updateStateUseJson = 'updateStateUseJson',
+    updateStateWebIfcSettings = 'updateStateWebIfcSettings',
+    updateModelStateTypes = 'updateModelStateTypes',
+    updateModelStateJsonData = 'updateModelStateJsonData',
+    loadJsonDataFromWorker = 'loadJsonDataFromWorker',
+    dispose = 'dispose',
+
+    // WebIFC Actions
+    Close = 'Close',
+    DisposeWebIfc = 'DisposeWebIfc',
+    Init = 'Init',
+    OpenModel = 'OpenModel',
+    CreateModel = 'CreateModel',
+    ExportFileAsIFC = 'ExportFileAsIFC',
+    GetGeometry = 'GetGeometry',
+    GetLine = 'GetLine',
+    GetAndClearErrors = 'GetAndClearErrors',
+    WriteLine = 'WriteLine',
+    FlattenLine = 'FlattenLine',
+    GetRawLineData = 'GetRawLineData',
+    WriteRawLineData = 'WriteRawLineData',
+    GetLineIDsWithType = 'GetLineIDsWithType',
+    GetAllLines = 'GetAllLines',
+    SetGeometryTransformation = 'SetGeometryTransformation',
+    GetCoordinationMatrix = 'GetCoordinationMatrix',
+    GetVertexArray = 'GetVertexArray',
+    GetIndexArray = 'GetIndexArray',
+    getSubArray = 'getSubArray',
+    CloseModel = 'CloseModel',
+    StreamAllMeshes = 'StreamAllMeshes',
+    StreamAllMeshesWithTypes = 'StreamAllMeshesWithTypes',
+    IsModelOpen = 'IsModelOpen',
+    LoadAllGeometry = 'LoadAllGeometry',
+    GetFlatMesh = 'GetFlatMesh',
+    SetWasmPath = 'SetWasmPath',
+    GetNameFromTypeCode = 'GetNameFromTypeCode',
+    GetIfcEntityList = 'GetIfcEntityList',
+    CreateIfcGuidToExpressIdMapping = 'CreateIfcGuidToExpressIdMapping',
+    GetTypeCodeFromName ='GetTypeCodeFromName',
+
+    // Parser
+    parse = 'parse',
+    setupOptionalCategories = 'setupOptionalCategories',
+
+    // Properties
+    getExpressId = 'getExpressId',
+    initializeProperties = 'initializeProperties',
+    getAllItemsOfType = 'getAllItemsOfType',
+    getItemProperties = 'getItemProperties',
+    getMaterialsProperties = 'getMaterialsProperties',
+    getPropertySets = 'getPropertySets',
+    getSpatialStructure = 'getSpatialStructure',
+    getTypeProperties = 'getTypeProperties',
+    getHeaderLine = 'getHeaderLine',
+}
+
+export enum WorkerAPIs {
+    workerState = 'workerState',
+    webIfc = 'webIfc',
+    properties = 'properties',
+    parser = 'parser',
+}
+
+export interface IfcEventData {
+    worker: WorkerAPIs;
+    action: WorkerActions;
+    args: any;
+    id: number;
+    result: any;
+    onProgress: boolean;
+}
+
+export interface RootWorker {
+    [WorkerAPIs.workerState]: WorkerStateAPI;
+    [WorkerAPIs.webIfc]: WebIfcWorkerAPI;
+    [WorkerAPIs.properties]: PropertyWorkerAPI;
+}
+
+export interface BaseWorkerAPI {
+    API: WorkerAPIs;
+}
+
+export type IfcWorkerEventHandler = (data: IfcEventData) => void;
+
+export interface WorkerStateAPI extends BaseWorkerAPI {
+    [WorkerActions.updateStateUseJson]: IfcWorkerEventHandler;
+    [WorkerActions.updateStateWebIfcSettings]: IfcWorkerEventHandler;
+    [WorkerActions.updateModelStateTypes]: IfcWorkerEventHandler;
+    [WorkerActions.updateModelStateJsonData]: IfcWorkerEventHandler;
+    [WorkerActions.loadJsonDataFromWorker]: IfcWorkerEventHandler;
+    [WorkerActions.dispose]: IfcWorkerEventHandler;
+}
+
+export interface PropertyWorkerAPI extends BaseWorkerAPI {
+    [WorkerActions.getAllItemsOfType]: IfcWorkerEventHandler;
+    [WorkerActions.getItemProperties]: IfcWorkerEventHandler;
+    [WorkerActions.getMaterialsProperties]: IfcWorkerEventHandler;
+    [WorkerActions.getPropertySets]: IfcWorkerEventHandler;
+    [WorkerActions.getSpatialStructure]: IfcWorkerEventHandler;
+    [WorkerActions.getTypeProperties]: IfcWorkerEventHandler;
+}
+
+export interface ParserWorkerAPI extends BaseWorkerAPI {
+    [WorkerActions.parse]: IfcWorkerEventHandler;
+    [WorkerActions.setupOptionalCategories]: IfcWorkerEventHandler;
+}
+
+export interface WebIfcWorkerAPI extends BaseWorkerAPI {
+    [WorkerActions.Init]: IfcWorkerEventHandler;
+    [WorkerActions.Close]: IfcWorkerEventHandler;
+    [WorkerActions.DisposeWebIfc]: IfcWorkerEventHandler;
+    [WorkerActions.OpenModel]: IfcWorkerEventHandler;
+    [WorkerActions.CreateModel]: IfcWorkerEventHandler;
+    [WorkerActions.ExportFileAsIFC]: IfcWorkerEventHandler;
+    [WorkerActions.GetGeometry]: IfcWorkerEventHandler;
+    [WorkerActions.GetLine]: IfcWorkerEventHandler;
+    [WorkerActions.GetAndClearErrors]: IfcWorkerEventHandler;
+    [WorkerActions.WriteLine]: IfcWorkerEventHandler;
+    [WorkerActions.FlattenLine]: IfcWorkerEventHandler;
+    [WorkerActions.GetRawLineData]: IfcWorkerEventHandler;
+    [WorkerActions.WriteRawLineData]: IfcWorkerEventHandler;
+    [WorkerActions.GetLineIDsWithType]: IfcWorkerEventHandler;
+    [WorkerActions.GetAllLines]: IfcWorkerEventHandler;
+    [WorkerActions.SetGeometryTransformation]: IfcWorkerEventHandler;
+    [WorkerActions.GetCoordinationMatrix]: IfcWorkerEventHandler;
+    [WorkerActions.GetVertexArray]: IfcWorkerEventHandler;
+    [WorkerActions.GetIndexArray]: IfcWorkerEventHandler;
+    [WorkerActions.getSubArray]: IfcWorkerEventHandler;
+    [WorkerActions.CloseModel]: IfcWorkerEventHandler;
+    [WorkerActions.StreamAllMeshes]: IfcWorkerEventHandler;
+    [WorkerActions.StreamAllMeshesWithTypes]: IfcWorkerEventHandler;
+    [WorkerActions.IsModelOpen]: IfcWorkerEventHandler;
+    [WorkerActions.LoadAllGeometry]: IfcWorkerEventHandler;
+    [WorkerActions.GetFlatMesh]: IfcWorkerEventHandler;
+    [WorkerActions.SetWasmPath]: IfcWorkerEventHandler;
+    [WorkerActions.GetNameFromTypeCode]: IfcWorkerEventHandler;
+    [WorkerActions.GetIfcEntityList]: IfcWorkerEventHandler;
+    [WorkerActions.CreateIfcGuidToExpressIdMapping]: IfcWorkerEventHandler;
+    [WorkerActions.GetTypeCodeFromName]: IfcWorkerEventHandler;
+}
+
+export interface SerializedVector {
+    [key: number]: any;
+
+    size: number;
+}
+
+export interface SerializedIfcGeometry {
+    GetVertexData: number;
+    GetVertexDataSize: number;
+    GetIndexData: number;
+    GetIndexDataSize: number;
+}
+
+export interface SerializedFlatMesh {
+    geometries: SerializedVector;
+    expressID: number;
+}
+
+export const ErrorStateNotAvailable = 'The state of the worker does not exist';
+export const ErrorRootStateNotAvailable = 'The root worker does not have any state';
+export const ErrorPropertiesNotAvailable = 'Error: Properties not available from web worker';
+export const ErrorParserNotAvailable = 'Error: Parser not available from web worker';
+export const ErrorBadJsonPath = 'Error: Model not available from web worker';
+export const ErrorBadJson = 'Error: The given Json could not be read as a JS object';

--- a/src/IFC/web-workers/handlers/WebIfcHandler.ts
+++ b/src/IFC/web-workers/handlers/WebIfcHandler.ts
@@ -1,0 +1,172 @@
+import { WebIfcAPI } from '../../BaseDefinitions';
+import {
+    
+    SerializedFlatMesh,
+    SerializedIfcGeometry,
+    SerializedVector,
+    WorkerActions,
+    WorkerAPIs
+} from '../BaseDefinitions';
+
+import { NewIfcModel, FlatMesh, IfcGeometry, LoaderError, LoaderSettings, RawLineData, Vector } from 'web-ifc';
+import { IFCWorkerHandler } from '../IFCWorkerHandler';
+import { Serializer } from '../serializer/Serializer';
+
+export class WebIfcHandler implements WebIfcAPI {
+
+    wasmModule: any;
+    API = WorkerAPIs.webIfc;
+
+    constructor(private handler: IFCWorkerHandler, private serializer: Serializer) {
+    }
+
+    async Init(): Promise<void> {
+        this.wasmModule = true;
+        return this.handler.request(this.API, WorkerActions.Init);
+    }
+
+    async OpenModel(data:  string | Uint8Array, settings?: LoaderSettings): Promise<number> {
+        return this.handler.request(this.API, WorkerActions.OpenModel, { data, settings });
+    }
+
+    async CreateModel(model: NewIfcModel, settings?: LoaderSettings): Promise<number> {
+        return this.handler.request(this.API, WorkerActions.CreateModel, { model, settings });
+    }
+
+    async ExportFileAsIFC(modelID: number): Promise<Uint8Array> {
+        return this.handler.request(this.API, WorkerActions.ExportFileAsIFC, { modelID });
+    }
+
+    async GetHeaderLine(modelID: number, headerType: number): Promise<any> {
+        return this.handler.request(this.API, WorkerActions.getHeaderLine, { modelID, headerType });
+    }
+
+    async GetGeometry(modelID: number, geometryExpressID: number): Promise<IfcGeometry> {
+        this.handler.serializeHandlers[this.handler.requestID] = (geom: SerializedIfcGeometry) => {
+            return this.serializer.reconstructIfcGeometry(geom);
+        }
+        return this.handler.request(this.API, WorkerActions.GetGeometry, { modelID, geometryExpressID });
+    }
+
+    async GetLine(modelID: number, expressID: number, flatten?: boolean): Promise<any> {
+        return this.handler.request(this.API, WorkerActions.GetLine, { modelID, expressID, flatten });
+    }
+
+    async GetAndClearErrors(modelID: number): Promise<Vector<LoaderError>> {
+        this.handler.serializeHandlers[this.handler.requestID] = (vector: SerializedVector) => {
+            return this.serializer.reconstructVector(vector);
+        }
+        return this.handler.request(this.API, WorkerActions.GetAndClearErrors, { modelID });
+    }
+
+    async GetNameFromTypeCode(type:number): Promise<string> {
+        return this.handler.request(this.API, WorkerActions.GetNameFromTypeCode, { type });
+    } 
+
+    async GetIfcEntityList(modelID: number) : Promise<number[]> {
+        return this.handler.request(this.API, WorkerActions.GetIfcEntityList, { modelID });
+    }
+
+    async CreateIfcGuidToExpressIdMapping(modelID: number): Promise<Map<string, number>> {
+        return this.handler.request(this.API, WorkerActions.CreateIfcGuidToExpressIdMapping, { modelID });
+    }
+
+    async GetTypeCodeFromName(typeName:string): Promise<number> {
+         return this.handler.request(this.API, WorkerActions.GetTypeCodeFromName, { typeName });
+    }
+
+    async WriteLine(modelID: number, lineObject: any): Promise<void> {
+        return this.handler.request(this.API, WorkerActions.WriteLine, { modelID, lineObject });
+    }
+
+    async FlattenLine(modelID: number, line: any): Promise<void> {
+        return this.handler.request(this.API, WorkerActions.FlattenLine, { modelID, line });
+    }
+
+    async GetRawLineData(modelID: number, expressID: number): Promise<RawLineData> {
+        return this.handler.request(this.API, WorkerActions.GetRawLineData, { modelID, expressID });
+    }
+
+    async WriteRawLineData(modelID: number, data: RawLineData): Promise<any> {
+        return this.handler.request(this.API, WorkerActions.WriteRawLineData, { modelID, data });
+    }
+
+    async GetLineIDsWithType(modelID: number, type: number): Promise<Vector<number>> {
+        this.handler.serializeHandlers[this.handler.requestID] = (vector: SerializedVector) => {
+            return this.serializer.reconstructVector(vector);
+        }
+        return this.handler.request(this.API, WorkerActions.GetLineIDsWithType, { modelID, type });
+    }
+
+    async GetAllLines(modelID: number): Promise<Vector<number>> {
+        this.handler.serializeHandlers[this.handler.requestID] = (vector: SerializedVector) => {
+            return this.serializer.reconstructVector(vector);
+        }
+        return this.handler.request(this.API, WorkerActions.GetAllLines, { modelID });
+    }
+
+    async SetGeometryTransformation(modelID: number, transformationMatrix: number[]): Promise<void> {
+        return this.handler.request(this.API, WorkerActions.SetGeometryTransformation, {
+            modelID,
+            transformationMatrix
+        });
+    }
+
+    async GetCoordinationMatrix(modelID: number): Promise<number[]> {
+        return this.handler.request(this.API, WorkerActions.GetCoordinationMatrix, { modelID });
+    }
+
+    async GetVertexArray(ptr: number, size: number): Promise<Float32Array> {
+        return this.handler.request(this.API, WorkerActions.GetVertexArray, { ptr, size });
+    }
+
+    async GetIndexArray(ptr: number, size: number): Promise<Uint32Array> {
+        return this.handler.request(this.API, WorkerActions.GetIndexArray, { ptr, size });
+    }
+
+    async getSubArray(heap: any, startPtr: any, sizeBytes: any): Promise<any> {
+        return this.handler.request(this.API, WorkerActions.getSubArray, { heap, startPtr, sizeBytes });
+    }
+
+    async CloseModel(modelID: number): Promise<void> {
+        return this.handler.request(this.API, WorkerActions.CloseModel, { modelID });
+    }
+
+    async StreamAllMeshes(modelID: number, meshCallback: (mesh: FlatMesh) => void): Promise<void> {
+        this.handler.callbackHandlers[this.handler.requestID] = {
+            action: meshCallback,
+            serializer: this.serializer.reconstructFlatMesh
+        };
+        return this.handler.request(this.API, WorkerActions.StreamAllMeshes, { modelID });
+    }
+
+    async StreamAllMeshesWithTypes(modelID: number, types: number[], meshCallback: (mesh: FlatMesh) => void): Promise<void> {
+        this.handler.callbackHandlers[this.handler.requestID] = {
+            action: meshCallback,
+            serializer: this.serializer.reconstructFlatMesh
+        };
+        return this.handler.request(this.API, WorkerActions.StreamAllMeshesWithTypes, { modelID, types });
+    }
+
+    async IsModelOpen(modelID: number): Promise<boolean> {
+        return this.handler.request(this.API, WorkerActions.IsModelOpen, { modelID });
+    }
+
+    async LoadAllGeometry(modelID: number): Promise<Vector<FlatMesh>> {
+        this.handler.serializeHandlers[this.handler.requestID] = (vector: SerializedVector) => {
+            return this.serializer.reconstructFlatMeshVector(vector);
+        }
+        return this.handler.request(this.API, WorkerActions.LoadAllGeometry, { modelID });
+    }
+
+    async GetFlatMesh(modelID: number, expressID: number): Promise<FlatMesh> {
+        this.handler.serializeHandlers[this.handler.requestID] = (flatMesh: SerializedFlatMesh) => {
+            return this.serializer.reconstructFlatMesh(flatMesh);
+        }
+        return this.handler.request(this.API, WorkerActions.GetFlatMesh, { modelID, expressID });
+    }
+
+    async SetWasmPath(path: string): Promise<void> {
+        return this.handler.request(this.API, WorkerActions.SetWasmPath, { path });
+    }
+}

--- a/src/IFC/web-workers/workers/WebIfcWorker.ts
+++ b/src/IFC/web-workers/workers/WebIfcWorker.ts
@@ -1,0 +1,203 @@
+import { IfcEventData, IfcWorkerAPI, WebIfcWorkerAPI, WorkerAPIs } from '../BaseDefinitions';
+import { IfcAPI } from 'web-ifc';
+import { Serializer } from '../serializer/Serializer';
+
+export class WebIfcWorker implements WebIfcWorkerAPI {
+
+    webIFC: IfcAPI;
+    API = WorkerAPIs.webIfc;
+
+    constructor(private worker: IfcWorkerAPI, private serializer: Serializer) {
+        this.webIFC = new IfcAPI();
+        this.worker.initializeAPI(this.webIFC);
+    }
+
+    async Init(data: IfcEventData) {
+        await this.webIFC.Init();
+        this.worker.post(data);
+    };
+
+    async Close(data: IfcEventData) {
+        this.nullifyWebIfc();
+        this.webIFC = new IfcAPI();
+        await this.webIFC.Init();
+        this.worker.post(data);
+    };
+
+    async DisposeWebIfc(data: IfcEventData) {
+        this.nullifyWebIfc();
+        this.worker.post(data);
+    }
+
+    CloseModel(data: IfcEventData) {
+        this.webIFC.CloseModel(data.args.modelID);
+        this.worker.post(data);
+    }
+
+    CreateModel(data: IfcEventData) {
+        data.result = this.webIFC.CreateModel(data.args.settings);
+        this.worker.post(data);
+    }
+
+    ExportFileAsIFC(data: IfcEventData) {
+        data.result = this.webIFC.ExportFileAsIFC(data.args.modelID);
+        this.worker.post(data);
+    }
+
+    FlattenLine(data: IfcEventData) {
+        this.webIFC.FlattenLine(data.args.modelID, data.args.line);
+        this.worker.post(data);
+    }
+
+    GetAllLines(data: IfcEventData) {
+        const vector = this.webIFC.GetAllLines(data.args.modelID);
+        data.result = this.serializer.serializeVector(vector);
+        this.worker.post(data);
+    }
+
+    GetAndClearErrors(data: IfcEventData) {
+        const vector = this.webIFC.GetAndClearErrors(data.args.modelID);
+        data.result = this.serializer.serializeVector(vector);
+        this.worker.post(data);
+    }
+
+    GetCoordinationMatrix(data: IfcEventData) {
+        data.result = this.webIFC.GetCoordinationMatrix(data.args.modelID);
+        this.worker.post(data);
+    }
+
+    GetFlatMesh(data: IfcEventData) {
+        const flatMesh = this.webIFC.GetFlatMesh(data.args.modelID, data.args.expressID);
+        data.result = this.serializer.serializeFlatMesh(flatMesh);
+        this.worker.post(data);
+    }
+
+    GetGeometry(data: IfcEventData) {
+        const ifcGeometry = this.webIFC.GetGeometry(data.args.modelID, data.args.geometryExpressID);
+        data.result = this.serializer.serializeIfcGeometry(ifcGeometry);
+        this.worker.post(data);
+    }
+
+    GetIndexArray(data: IfcEventData) {
+        data.result = this.webIFC.GetIndexArray(data.args.ptr, data.args.size);
+        this.worker.post(data);
+    }
+
+    GetLine(data: IfcEventData) {
+        const args = data.args;
+        try {
+           data.result = this.webIFC.GetLine(args.modelID, args.expressID, args.flatten);
+        } catch (e) {
+            console.log(`There was a problem getting the properties of the item ${args.expressID}`);
+            data.result = {};
+        }
+        this.worker.post(data);
+    }
+
+    GetLineIDsWithType(data: IfcEventData) {
+        const vector = this.webIFC.GetLineIDsWithType(data.args.modelID, data.args.type);
+        data.result = this.serializer.serializeVector(vector);
+        this.worker.post(data);
+    }
+
+    GetRawLineData(data: IfcEventData) {
+        data.result = this.webIFC.GetRawLineData(data.args.modelID, data.args.expressID);
+        this.worker.post(data);
+    }
+
+    GetVertexArray(data: IfcEventData) {
+        data.result = this.webIFC.GetVertexArray(data.args.ptr, data.args.size);
+        this.worker.post(data);
+    }
+
+    IsModelOpen(data: IfcEventData) {
+        data.result = this.webIFC.IsModelOpen(data.args.modelID);
+        this.worker.post(data);
+    }
+
+    LoadAllGeometry(data: IfcEventData) {
+        const flatMeshVector = this.webIFC.LoadAllGeometry(data.args.modelID);
+        data.result = this.serializer.serializeFlatMeshVector(flatMeshVector);
+        this.worker.post(data);
+    }
+
+    OpenModel(data: IfcEventData) {
+        data.result = this.webIFC.OpenModel(data.args.data, data.args.settings);
+        this.worker.post(data);
+    }
+
+    SetGeometryTransformation(data: IfcEventData) {
+        this.webIFC.SetGeometryTransformation(data.args.modelID, data.args.transformationMatrix);
+        this.worker.post(data);
+    }
+
+    SetWasmPath(data: IfcEventData) {
+        this.webIFC.SetWasmPath(data.args.path);
+        this.worker.post(data);
+    }
+
+    StreamAllMeshes(data: IfcEventData) {
+        const serializer = this.serializer.serializeFlatMesh;
+        const callback = (result: any) => this.worker.postCallback(data, result, serializer);
+        this.webIFC.StreamAllMeshes(data.args.modelID, callback);
+    }
+
+    StreamAllMeshesWithTypes(data: IfcEventData) {
+        const args = data.args;
+        const serializer = this.serializer.serializeFlatMesh;
+        const callback = (result: any) => this.worker.postCallback(data, result, serializer);
+        this.webIFC.StreamAllMeshesWithTypes(args.modelID, args.types, callback);
+    }
+
+    WriteLine(data: IfcEventData) {
+        const modelID = data.args.modelID;
+        const serializedObject = data.args.lineObject;
+
+        // This is necessary because of the serialization of the web worker
+        const object = this.webIFC.GetLine(modelID, serializedObject.expressID);
+        Object.keys(serializedObject).forEach(propName => {
+            if(object[propName] !== undefined) {
+                object[propName] = serializedObject[propName];
+            }
+        })
+
+        this.webIFC.WriteLine(data.args.modelID, object);
+        this.worker.post(data);
+    }
+
+    WriteRawLineData(data: IfcEventData) {
+        this.webIFC.WriteRawLineData(data.args.modelID, data.args.data);
+        this.worker.post(data);
+    }
+
+    getSubArray(data: IfcEventData) {
+        const args = data.args;
+        this.webIFC.getSubArray(args.heap, args.startPtr, args.sizeBytes);
+        this.worker.post(data);
+    }
+
+    GetNameFromTypeCode(data: IfcEventData) {
+        data.result=this.webIFC.GetNameFromTypeCode(data.args.modelID);
+        this.worker.post(data);
+    }
+
+    GetIfcEntityList(data: IfcEventData) {
+        data.result=this.webIFC.GetIfcEntityList(data.args.modelID);
+        this.worker.post(data);
+    }
+
+    CreateIfcGuidToExpressIdMapping(data: IfcEventData) {
+        data.result = this.webIFC.CreateIfcGuidToExpressIdMapping(data.args.modelID);
+        this.worker.post(data);
+    }
+
+    GetTypeCodeFromName(data: IfcEventData) {
+        data.result=this.webIFC.GetTypeCodeFromName(data.args.typeName);
+        this.worker.post(data);
+    }
+
+    private nullifyWebIfc() {
+        // @ts-ignore
+        this.webIFC = null;
+    }
+}

--- a/test/IFC/WebWorkers/WebIfcHandler.test.ts
+++ b/test/IFC/WebWorkers/WebIfcHandler.test.ts
@@ -1,0 +1,23 @@
+import { WebIfcHandler } from "../../../src/IFC/web-workers/handlers/WebIfcHandler";
+import { WorkerActions, WorkerAPIs } from "../../../src/IFC/web-workers/BaseDefinitions";
+
+describe("WebIfcHandler", () => {
+    test("CreateIfcGuidToExpressIdMapping forwards the request to the web-ifc worker", async () => {
+        const expected = new Map([["guid", 42]]);
+        const handler = {
+            requestID: 0,
+            request: jest.fn().mockResolvedValue(expected)
+        };
+        const serializer = {};
+        const webIfcHandler = new WebIfcHandler(handler as any, serializer as any);
+
+        const result = await webIfcHandler.CreateIfcGuidToExpressIdMapping(7);
+
+        expect(handler.request).toHaveBeenCalledWith(
+            WorkerAPIs.webIfc,
+            WorkerActions.CreateIfcGuidToExpressIdMapping,
+            { modelID: 7 }
+        );
+        expect(result).toBe(expected);
+    });
+});


### PR DESCRIPTION
## Summary

Adds worker support for `CreateIfcGuidToExpressIdMapping(modelID)` so consumers using the WebWorker-backed API can build GUID-to-expressID mappings the same way they can when calling `web-ifc` directly.

## Changes

- Adds `CreateIfcGuidToExpressIdMapping` to the shared `WebIfcAPI` interface.
- Adds a matching `WorkerActions` entry and `WebIfcWorkerAPI` handler contract.
- Forwards the call through `WebIfcHandler` to the worker.
- Executes the call inside `WebIfcWorker` and posts the resulting map back.
- Adds a small unit test covering the worker handler forwarding behavior.

## Verification

- `npm.cmd test -- --runInBand test/IFC/WebWorkers/WebIfcHandler.test.ts` could not run because this source archive does not include installed dependencies and `jest` is not available locally.
